### PR TITLE
docs links: dev, stable (v0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 [![Build Status](https://travis-ci.org/SimonEnsemble/Xtals.jl.svg?branch=master)](https://travis-ci.org/SimonEnsemble/Xtals.jl)
 [![Coverage Status](https://coveralls.io/repos/github/SimonEnsemble/Xtals.jl/badge.svg?branch=master)](https://coveralls.io/github/SimonEnsemble/Xtals.jl?branch=master)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://SimonEnsemble.github.io/Xtals.jl/dev)
+[![](https://img.shields.io/badge/docs-stable-green.svg)](https://SimonEnsemble.github.io/Xtals.jl/stable)
+
 
 A pure-[Julia](https://julialang.org/) package for importing, manipulating, and working with crystal structures, such as metal-organic frameworks (MOFs).


### PR DESCRIPTION
nothing to do with coveralls.  thought I would fix it, turns out my fix did nothing.  but I did add the link to the other docs version.