### PR TITLE
write_cssr function

### DIFF
--- a/src/Xtals.jl
+++ b/src/Xtals.jl
@@ -115,7 +115,7 @@ export
     # crystal.jl
     Crystal, strip_numbers_from_atom_labels!, assign_charges,
     chemical_formula, molecular_weight, crystal_density, write_cif, has_charges,
-    apply_symmetry_operations,
+    apply_symmetry_operations, write_cssr,
 
     # bonds.jl
     infer_bonds!, write_bond_information, BondingRule, bond_sanity_check,

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -930,7 +930,29 @@ function write_cif(crystal::Crystal, filename::String; fractional_coords::Bool=t
     close(cif_file)
 end
 
-write_cif(crystal::Crystal) = write_cif(crystal, crystal.name)
+write_cif(crystal::Crystal) = write_cif(crystal, String(split(crystal.name, ".")[1]))
+
+function write_cssr(xtal::Crystal, filename::String)
+    @assert xtal.symmetry.is_p1 "crystal must be in P1 symmetry"
+    if ! occursin(".cssr", filename)
+        filename *= ".cssr"
+    end
+    f = open(filename, "w")
+    @printf(f, "%f %f %f\n", xtal.box.a, xtal.box.b, xtal.box.c)
+    @printf(f, "%f %f %f SPGR = 1 P 1   OPT = 1\n", rad2deg(xtal.box.α), rad2deg(xtal.box.β), rad2deg(xtal.box.γ))
+    @printf(f, "%d 0\n0 xtal : xtal", xtal.atoms.n)
+    for a = 1:xtal.atoms.n
+        q = 0.0
+        if xtal.charges.n != 0
+            q = xtal.charges.q[a]
+        end
+        @printf(f, "\n%d %s %f %f %f 0 0  0  0  0  0  0  0  %f", a, xtal.atoms.species[a], xtal.atoms.coords.xf[:, a]..., q, )
+    end
+    close(f)
+    @info "see $filename"
+end
+
+write_cssr(crystal::Crystal) = write_cssr(crystal, String(split(crystal.name, ".")[1]))
 
 """
     crystal = remove_duplicate_atoms_and_charges(crystal, r_tol=0.1, q_tol=0.0001, verbose=false)
@@ -1019,7 +1041,7 @@ end
 
 function Base.isapprox(c1::Crystal, c2::Crystal; atol::Real=0.0)
     # name not included
-    box_flag = isapprox(c1.box, c2.box)
+    box_flag = isapprox(c1.box, c2.box, atol=atol)
     if c1.charges.n != c2.charges.n
         return false
     end

--- a/test/crystal.jl
+++ b/test/crystal.jl
@@ -167,6 +167,13 @@ end
     strip_numbers_from_atom_labels!(xtal_cif)
     @test isapprox(xtal_cif, xtal_cssr)
 
+    da_xtalname = "ATIBOU01_clean"
+    xtal_cif = Crystal(da_xtalname * ".cif", include_zero_charges=true)
+    write_cssr(xtal_cif)
+    write_cssr(xtal_cif, joinpath(Xtals.PATH_TO_CRYSTALS, da_xtalname * ".cssr"))
+    xtal_cssr = Crystal(da_xtalname * ".cssr", include_zero_charges=true)
+    @test isapprox(xtal_cssr, xtal_cif, atol=0.0001)
+
     # sanity checks on replicate crystal
     sbmof = Crystal("SBMOF-1.cif")
     strip_numbers_from_atom_labels!(sbmof)


### PR DESCRIPTION
a `write_cssr` function with a test.

@eahenle you might need this to convert to `.cssr` for Zeo++ which I think requires `.cssr` inputs. please patch if Zeo++ is picky about spaces etc.