### PR TITLE
v0.3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Xtals"
 uuid = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 authors = ["SimonEnsemble <cory.simon@oregonstate.edu>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Bio3DView = "99c8bb3a-9d13-5280-9740-b4880ed9c598"

--- a/docs/src/bonds.md
+++ b/docs/src/bonds.md
@@ -58,7 +58,7 @@ Some chemical information formats, like `.cif` and `.mol`, can store not only th
 
 ## Bond distances, vectors, and angles
 
-When `infer_bonds!` is called, it labels each bond with several additional pieces of information.  The first is the center-to-center distance between the bonded atoms,
+Bonds may be labeled with several additional pieces of information.  The first is the center-to-center distance between the bonded atoms,
 accessible via `bond_distance`:
 
 ```jldoctest bonds
@@ -67,9 +67,10 @@ bond_distance(xtal, 1, 5)
 1.5233240952030063
 ```
 
-`infer_bonds!` additionally employs the function `calculate_bond_vectors!` to label each edge in the bonding graph with a vector, accessible via `get_bond_vector`:
+The bond distance is automatically added by `infer_bonds!`. Applying `calculate_bond_vectors!` (or passing `calculate_vectors=true` to `infer_bonds!`) labels each edge in the bonding graph with a vector, accessible via `get_bond_vector`:
 
 ```jldoctest bonds
+calculate_bond_vectors!(xtal)
 get_bond_vector(xtal, 1, 5)
 # output
 3-element Vector{Float64}:

--- a/src/Xtals.jl
+++ b/src/Xtals.jl
@@ -64,6 +64,9 @@ export
     infer_bonds!, write_bond_information, BondingRule, bond_sanity_check, remove_bonds!, 
     infer_geometry_based_bonds!, get_bonding_rules, set_bonding_rules, read_bonding_rules,
     write_bonding_rules, add_bonding_rules, drop_cross_pb_bonds!, bondingrules, bond_angle,
-    get_bond_vector, calculate_bond_vectors!, clear_vectors!, bond_distance
+    get_bond_vector, calculate_bond_vectors!, clear_vectors!, bond_distance,
+
+    # pydeps.jl
+    export_pydep, check_pydep, init_pydeps
 
 end # module Xtals

--- a/src/bonds.jl
+++ b/src/bonds.jl
@@ -207,9 +207,10 @@ The bonding rules are hierarchical, i.e. the first bonding rule takes precedence
 - `crystal::Crystal`: The crystal that bonds will be added to
 - `include_bonds_across_periodic_boundaries::Bool`: Whether to check across the periodic boundary when calculating bonds
 - `bonding_rules::Union{Array{BondingRule, 1}, Nothing}=nothing`: The array of bonding rules that will be used to fill the bonding information. They are applied in the order that they appear. if `nothing`, default bonding rules will be applied; see [`get_bonding_rules`](@ref)
+- `calculate_vectors::Bool`: Optional. Set `true` to annotate all edges in the `bonds` graph with vector information.
 """
 function infer_bonds!(crystal::Crystal, include_bonds_across_periodic_boundaries::Bool;
-                      bonding_rules::Array{BondingRule, 1}=rc[:bonding_rules])
+                      bonding_rules::Array{BondingRule, 1}=rc[:bonding_rules], calculate_vectors::Bool=false)
     @assert ne(crystal.bonds) == 0 @sprintf("The crystal %s already has bonds. Remove them with the `remove_bonds!` function before inferring new ones.", crystal.name)
     # loop over every atom
     for i in 1:crystal.atoms.n
@@ -224,7 +225,9 @@ function infer_bonds!(crystal::Crystal, include_bonds_across_periodic_boundaries
             end
         end
     end
-    calculate_bond_vectors!(crystal)
+    if calculate_vectors
+        calculate_bond_vectors!(crystal)
+    end
     bond_sanity_check(crystal)
 end
 

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -1114,5 +1114,6 @@ function primitive_cell(xtal::Crystal)
     primitive = Crystal(tempfile)
     # clean up
     rm(tempfile)
-    return primitive
+    name = split(xtal.name, ".cif")[1] * "_primitive_cell.cif"
+    return Crystal(name, primitive.box, primitive.atoms, primitive.charges)
 end


### PR DESCRIPTION
- Exports functions for working with Python dependencies.  Closes #88
- Fixes crystal names when converting to primitive cell.  Closes #89 
- Makes bond vector info optional. Closes #90