### PR TITLE
Allow vectors of indices while computing distance

### DIFF
--- a/src/distance.jl
+++ b/src/distance.jl
@@ -39,16 +39,16 @@ apply periodic boundary conditions if and only if `apply_pbc` is `true`.
 - `j::Int`: Index of the second particle
 - `apply_pbc::Bool`: `true` if we wish to apply periodic boundary conditions, `false` otherwise
 """
-function distance(coords::Frac, box::Box, i::Int, j::Int, apply_pbc::Bool)
-    dxf = coords.xf[:, i] - coords.xf[:, j]
+function distance(coords::Frac, box::Box, i, j, apply_pbc::Bool)
+    dxf = @views coords.xf[:, i] - coords.xf[:, j]
     if apply_pbc
         nearest_image!(dxf)
     end
     return norm(box.f_to_c * dxf)
 end
 
-function distance(coords::Cart, box::Box, i::Int, j::Int, apply_pbc::Bool)
-    dx = coords.x[:, i] - coords.x[:, j]
+function distance(coords::Cart, box::Box, i, j, apply_pbc::Bool)
+    dx = @views coords.x[:, i] - coords.x[:, j]
     if apply_pbc
         dxf = box.c_to_f * dx
         nearest_image!(dxf)
@@ -59,8 +59,8 @@ function distance(coords::Cart, box::Box, i::Int, j::Int, apply_pbc::Bool)
 end
 
 # no PBCs
-function distance(coords::Cart, i::Int, j::Int)
-    dx = coords.x[:, i] - coords.x[:, j]
+function distance(coords::Cart, i, j)
+    dx = @views coords.x[:, i] - coords.x[:, j]
     return norm(dx)
 end
 distance(atoms::Atoms{Cart}, i::Int, j::Int) = distance(atoms.coords, i, j)


### PR DESCRIPTION
Currently the typing on in the methods means that while the functions themselves are fine, if one wants to compute the distances of certain index pairs, they have to write a loop. This allows users to pass in either ints or vectors of ints with no penalty to the performance. Another happy improvement is that this would make reverse mode AD like Zygote efficient over large index pairs since it would move from scalar operations to optionally array operations.