### PR TITLE
Docstring fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Xtals"
 uuid = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 authors = ["SimonEnsemble <cory.simon@oregonstate.edu>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Bio3DView = "99c8bb3a-9d13-5280-9740-b4880ed9c598"

--- a/src/bonds.jl
+++ b/src/bonds.jl
@@ -192,21 +192,18 @@ end
 
 
 """
-    infer_bonds!(crystal, include_bonds_across_periodic_boundaries, bonding_rules=nothing)
+    infer_bonds!(crystal, include_bonds_across_periodic_boundaries; bonding_rules=rc[:bonding_rules])
 
-Populate the bonds in the crystal object based on the bonding rules. If a
-pair doesn't have a suitable rule then they will not be considered bonded.
+Populate the bonds in the crystal object based on the bonding rules. If a pair doesn't have a suitable rule then they will not be considered bonded.
 
-`:*` is considered a wildcard and can be substituted for any species. It is a
-good idea to include a bonding rule between two `:*` to allow any atoms to bond
-as long as they are close enough.
+`:*` is considered a wildcard and can be substituted for any species. It is a good idea to include a bonding rule between two `:*` to allow any atoms to bond as long as they are close enough.
 
 The bonding rules are hierarchical, i.e. the first bonding rule takes precedence over the latter ones.
 
 # Arguments
-- `crystal::Crystal`: The crystal that bonds will be added to
-- `include_bonds_across_periodic_boundaries::Bool`: Whether to check across the periodic boundary when calculating bonds
-- `bonding_rules::Union{Array{BondingRule, 1}, Nothing}=nothing`: The array of bonding rules that will be used to fill the bonding information. They are applied in the order that they appear. if `nothing`, default bonding rules will be applied; see [`get_bonding_rules`](@ref)
+- `crystal::Crystal`: The crystal that bonds will be added to.
+- `include_bonds_across_periodic_boundaries::Bool`: Whether to check across the periodic boundary when calculating bonds.
+- `bonding_rules::Array{BondingRule, 1}`: The array of bonding rules that will be used to fill the bonding information. They are applied in the order that they appear. `rc[:bonding_rules]` will be used if none provided.
 - `calculate_vectors::Bool`: Optional. Set `true` to annotate all edges in the `bonds` graph with vector information.
 """
 function infer_bonds!(crystal::Crystal, include_bonds_across_periodic_boundaries::Bool;


### PR DESCRIPTION
fixes the docstring for `infer_bonds!`

the wrong type was indicated for the `bonding_rules` kwarg