### PR TITLE
`getindex` returns new type

### DIFF
--- a/src/Xtals.jl
+++ b/src/Xtals.jl
@@ -45,7 +45,7 @@ export
     rc,
 
     # matter.jl
-    Coords, Frac, Cart, Atoms, Charges, wrap!, neutral, net_charge, translate_by!,
+    Coords, Frac, Cart, Atoms, Atom, Charges, wrap!, neutral, net_charge, translate_by!,
 
     # box.jl
     Box, replicate, unit_cube, write_vtk, inside, fractional_coords, cartesian_coords,

--- a/src/matter.jl
+++ b/src/matter.jl
@@ -137,14 +137,36 @@ function Atoms(species::Array{Symbol, 1}, coords::Coords)
     return Atoms(length(species), species, coords)
 end
 
+"""
+Representation of a single atom at some point in space.
+
+```julia
+struct Atom{T<:Coords} # enforce that the type specified is `Coords`
+    species::Symbol # list of species
+    coords::T # coordinates
+end
+```
+
+here, `T` is `Frac` or `Cart`.
+"""
+struct Atom{T<:Coords}
+    species::Symbol
+    coords::T
+end
+
 Atoms(species::Symbol, coords::Coords) = Atoms([species], coords)
 Atoms{Frac}(n::Int) = Atoms([:_ for a = 1:n], Frac([NaN for i = 1:3, a = 1:n])) # safe pre-allocation
 Atoms{Cart}(n::Int) = Atoms([:_ for a = 1:n], Cart([NaN for i = 1:3, a = 1:n])) # safe pre-allocation
 
 Base.isapprox(a1::Atoms, a2::Atoms; atol::Real=0) = (a1.species == a2.species) && isapprox(a1.coords, a2.coords, atol=atol)
+Base.isapprox(a1::Atom, a2::Atom; atol::Real=0) = (a1.species == a2.species) && isapprox(a1.coords, a2.coords, atol=atol)
 Base.:+(a1::Atoms, a2::Atoms) = Atoms(a1.n + a2.n, [a1.species; a2.species], hcat(a1.coords, a2.coords))
+Base.:+(a1::Atoms, a2::Atom) = Atoms(a1.n + 1, [a1.species; a2.species], hcat(a1.coords, a2.coords))
+Base.:+(a1::Atom, a2::Atoms) = Atoms(1 + a2.n, [a1.species; a2.species], hcat(a1.coords, a2.coords))
+Base.:+(a1::Atom, a2::Atom) = Atoms(2, [a1.species; a2.species], hcat(a1.coords, a2.coords))
 
 Base.getindex(atoms::Atoms, ids) = Atoms(atoms.species[ids], atoms.coords[ids])
+Base.getindex(atoms::Atoms, id::Int) = Atom(atoms.species[id], atoms.coords[id])
 Base.lastindex(atoms::Atoms) = atoms.n
 
 

--- a/test/matter.jl
+++ b/test/matter.jl
@@ -34,6 +34,10 @@ using Test
     ## Atoms
     a1_f = Atoms(s1, f1)
     a2_f = Atoms(s2, f2)
+    a1_f_1 = Atom(s1[1], f1[1])
+    a1_f_2 = Atom(s1[2], f1[2])
+    @test isapprox(a1_f, a1_f_1 + a1_f_2)
+    @test isapprox(a1_f[1], a1_f_1)
 
     a1_c = Atoms(s1, c1)
     a2_c = Atoms(s2, c2)


### PR DESCRIPTION
Resolves #102 

So far I have only very barebones stuff. Questions for core devs/maintainers:

1. Should I add a check so that if a user tries to construct an `Atoms` object with only one atom, an `Atom` object is returned instead?
2. Do you mind if I define a similar `getindex` dispatch for `Crystal` (i.e. if you call it with a single `Int` index, it returns a corresponding `Atom` object? Currently, `getindex(::Crystal, Int)` errors, so this shouldn't break any existing workflows, but it does discard some information, so I wasn't sure if you'd rather I handle that case another way. (For your reference, I'm planning to have `Crystal` be the subtype of `AbstractSystem` in the AtomsBase interface so that box and boundary condition info can be there, so this `getindex` would need to be there, [see here](https://github.com/JuliaMolSim/AtomsBase.jl/blob/73451366c6fbc24da94cbe53758bf222146315e0/src/interface.jl#L84)). If that sounds okay, I'll go ahead and do it and add some tests for that case too.
3. In the spirit of `Atom` being a "view" of `Atoms`, one other thing we could consider would be to have the `Atom` store a reference to the `Atoms` object from which it came ([a la `DataFrameRow`](https://github.com/JuliaData/DataFrames.jl/blob/main/src/dataframerow/dataframerow.jl)). Didn't put this in for now, but happy to do so pending your thoughts.
4. Do you want me to add more exhaustive tests (so far I only added an analogy test for one of the fractional coordinate cases)

I'll plan on a separate PR to actually implement the AtomsBase interface itself once we've actually registered that package. In the meantime, feel free to [take a look](https://github.com/JuliaMolSim/AtomsBase.jl) (there should be a proper README in the next day or two) and open/comment on issues if you have thoughts!