### PR TITLE
Slice props

### DIFF
--- a/src/bonds.jl
+++ b/src/bonds.jl
@@ -192,21 +192,18 @@ end
 
 
 """
-    infer_bonds!(crystal, include_bonds_across_periodic_boundaries, bonding_rules=nothing)
+    infer_bonds!(crystal, include_bonds_across_periodic_boundaries; bonding_rules=rc[:bonding_rules])
 
-Populate the bonds in the crystal object based on the bonding rules. If a
-pair doesn't have a suitable rule then they will not be considered bonded.
+Populate the bonds in the crystal object based on the bonding rules. If a pair doesn't have a suitable rule then they will not be considered bonded.
 
-`:*` is considered a wildcard and can be substituted for any species. It is a
-good idea to include a bonding rule between two `:*` to allow any atoms to bond
-as long as they are close enough.
+`:*` is considered a wildcard and can be substituted for any species. It is a good idea to include a bonding rule between two `:*` to allow any atoms to bond as long as they are close enough.
 
 The bonding rules are hierarchical, i.e. the first bonding rule takes precedence over the latter ones.
 
 # Arguments
-- `crystal::Crystal`: The crystal that bonds will be added to
-- `include_bonds_across_periodic_boundaries::Bool`: Whether to check across the periodic boundary when calculating bonds
-- `bonding_rules::Union{Array{BondingRule, 1}, Nothing}=nothing`: The array of bonding rules that will be used to fill the bonding information. They are applied in the order that they appear. if `nothing`, default bonding rules will be applied; see [`get_bonding_rules`](@ref)
+- `crystal::Crystal`: The crystal that bonds will be added to.
+- `include_bonds_across_periodic_boundaries::Bool`: Whether to check across the periodic boundary when calculating bonds.
+- `bonding_rules::Array{BondingRule, 1}`: The array of bonding rules that will be used to fill the bonding information. They are applied in the order that they appear. `rc[:bonding_rules]` will be used if none provided.
 - `calculate_vectors::Bool`: Optional. Set `true` to annotate all edges in the `bonds` graph with vector information.
 """
 function infer_bonds!(crystal::Crystal, include_bonds_across_periodic_boundaries::Bool;

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -1023,28 +1023,25 @@ end
 
 
 # slicing of crystal by arrays of Int's
-function Base.getindex(crystal::Crystal,
-                       ids::Union{Array{Int, 1}, UnitRange{Int}})
+function Base.getindex(crystal::Crystal, ids::Union{Array{Int, 1}, UnitRange{Int}})
     # mapping from old index to new index
     old_to_new = Dict(ids[i] => i for i in 1:length(ids))
+    # create appropriately sized graph
     bonds = MetaGraph(length(ids))
+    # copy bonds from within slice
     for edge in edges(crystal.bonds)
         if edge.src in ids && edge.dst in ids
             add_edge!(bonds, old_to_new[edge.src], old_to_new[edge.dst])
-            set_props!(bonds, old_to_new[edge.src], old_to_new[edge.dst],
-                       props(bonds, edge.src, edge.dst))
+            set_props!(bonds, old_to_new[edge.src], old_to_new[edge.dst], props(crystal.bonds, edge.src, edge.dst))
         end
     end
     if crystal.charges.n == 0
-        return Crystal(crystal.name, crystal.box, crystal.atoms[ids],
-            crystal.charges, bonds, crystal.symmetry)
+        return Crystal(crystal.name, crystal.box, crystal.atoms[ids], crystal.charges, bonds, crystal.symmetry)
     elseif (crystal.charges.n == crystal.atoms.n) &&
             isapprox(crystal.charges.coords, crystal.atoms.coords)
-        return Crystal(crystal.name, crystal.box, crystal.atoms[ids],
-            crystal.charges[ids], bonds, crystal.symmetry)
+        return Crystal(crystal.name, crystal.box, crystal.atoms[ids], crystal.charges[ids], bonds, crystal.symmetry)
     else
-        error("for getindex(crystal), crystal must have 0 charges or an equal number of charges and atoms
-        that share coordinates")
+        error("for getindex(crystal), crystal must have 0 charges or an equal number of charges and atoms that share coordinates")
     end
     return crystal
 end


### PR DESCRIPTION
fixes a bug in `getindex(::Crystal, ::Vector)` that caused sliced crystals to have empty edge attribute dicts