### PR TITLE
default comment

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -55,7 +55,7 @@ if the extension is not provided.)
 - `comment::AbstractString`: comment if you'd like to write to the file.
 - `center_at_origin::Bool`: (for crystal only) if `true`, translate all coords such that the origin is the center of the unit cell.
 """
-function write_xyz(atoms::Atoms{Cart}, filename::AbstractString; comment::AbstractString="")
+function write_xyz(atoms::Atoms{Cart}, filename::AbstractString; comment::AbstractString="# $filename")
     filename = add_extension(filename, ".xyz")
 
     xyzfile = open(filename, "w")


### PR DESCRIPTION
closes #132 

makes the default comment for `write_xyz` the `filename` arg