### PR TITLE
partial implementation of AtomsBase interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["SimonEnsemble <cory.simon@oregonstate.edu>"]
 version = "0.3.10"
 
 [deps]
+AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 Bio3DView = "99c8bb3a-9d13-5280-9740-b4880ed9c598"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -16,7 +17,9 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Bio3DView = "^0.1.3"

--- a/src/Xtals.jl
+++ b/src/Xtals.jl
@@ -1,6 +1,6 @@
 module Xtals
 
-using Bio3DView, CSV, DataFrames, FIGlet, Graphs, LinearAlgebra, MetaGraphs, Printf, UUIDs
+using AtomsBase, Bio3DView, CSV, DataFrames, FIGlet, Graphs, LinearAlgebra, MetaGraphs, Printf, StaticArrays, Unitful, UUIDs
 
 # global variable dictionary
 global rc = Dict{Symbol,Any}()
@@ -52,6 +52,8 @@ export
     # crystal.jl
     Crystal, strip_numbers_from_atom_labels!, assign_charges, chemical_formula, molecular_weight, 
     crystal_density, write_cif, has_charges, apply_symmetry_operations, write_cssr, 
+    # AtomsBase things also from crystal
+    position, velocity, bounding_box, boundary_conditions,
 
     # bonds.jl
     infer_bonds!, write_bond_information, BondingRule, bond_sanity_check, remove_bonds!, 

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -17,7 +17,7 @@ struct SymmetryInfo
 end
 SymmetryInfo() = SymmetryInfo([Array{String, 2}(undef, 3, 0) ["x", "y", "z"]], "P1", true) # default
 
-struct Crystal
+struct Crystal <: AbstractAtomicSystem{3}
     name::String
     box::Box
     atoms::Atoms{Frac}
@@ -1091,3 +1091,19 @@ function Base.:+(crystals::Crystal...; check_overlap::Bool=true, name::String="a
 
     return crystal
 end
+
+# AtomsBase interface things...NB that the indexing/iteration aspects aren't included because they would conflict with how slicing is defined in this package
+import Base.position
+import AtomsBase.velocity
+import AtomsBase.bounding_box
+import AtomsBase.boundary_conditions
+
+function position(crystal::Crystal)
+    pos = Cart(crystal.atoms.coords, crystal.box).x
+    return [pos[:,i] for i in 1:size(pos,2)] * u"Å"
+end
+
+velocity(::Crystal) = missing
+
+bounding_box(crystal::Crystal) = SVector{3}([SVector{3}(crystal.box.f_to_c[:,i]u"Å") for i in 1:3])
+boundary_conditions(::Crystal) = SVector{3,BoundaryCondition}([Periodic(), Periodic(), Periodic()])

--- a/test/crystal.jl
+++ b/test/crystal.jl
@@ -4,6 +4,7 @@ using Xtals
 using LinearAlgebra
 using Test
 using MetaGraphs, Graphs
+using AtomsBase
 
 # for test only
 # if the multi sets are equal, then when you remove duplicates,
@@ -21,6 +22,16 @@ end
     @test Xtals.vtk_filename(xtal) == "SBMOF-1.vtk"
     xtal = Crystal("ATIBOU01_clean.cssr")
     @test Xtals.vtk_filename(xtal) == "ATIBOU01_clean.vtk"
+
+    # AtomsBase stuff
+    xtal = Crystal("SBMOF-1.cif")
+    pos = position(xtal)
+    @test length(pos) == 120
+    @test isapprox(pos[1][2].val, 1.43954862, atol=1e-9)
+    @test ismissing(velocity(xtal))
+    @test bounding_box(xtal)[1][1].val == xtal.box.a
+    @test periodicity(xtal) == [1,1,1]
+    @test n_dimensions(xtal) == 3
 
     # cif reader
     xtal = Crystal("test_structure2.cif")


### PR DESCRIPTION
👋 We've finally actually registered v0.1.0 of [AtomsBase](https://github.com/JuliaMolSim/AtomsBase.jl) and are sending around some PR's to help adoption!

I've left off the indexing bits for now but the other pieces all work! (tagging my co-devs on AtomsBase to pin this as a discussion point regarding slicing @mfherbst @jgreener64 @Gregstrq)

I'm leaving this as a draft PR for now because the current registered version of AtomsBase has a `show` method that breaks yours (specifically, because you've only implemented [one of the `show` methods](https://docs.julialang.org/en/v1/manual/types/#man-custom-pretty-printing)) because it's a partial implementation and some methods that I haven't implemented here are needed. Also, IMO we shouldn't have actually included the `show` method at all; I have a [PR](https://github.com/JuliaMolSim/AtomsBase.jl/pull/32) to fix it with a patch version and once that is merged I'll change the deps here and convert this to a real PR...