### PR TITLE
fix name clash

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Xtals"
 uuid = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 authors = ["SimonEnsemble <cory.simon@oregonstate.edu>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/Xtals.jl
+++ b/src/Xtals.jl
@@ -51,7 +51,7 @@ export
 
     # crystal.jl
     Crystal, strip_numbers_from_atom_labels!, assign_charges, empirical_formula, molecular_weight, 
-    crystal_density, write_cif, has_charges, apply_symmetry_operations, write_cssr, rename,
+    crystal_density, write_cif, has_charges, apply_symmetry_operations, write_cssr, rename_xtal,
     # AtomsBase things also from crystal
     position, velocity, bounding_box, boundary_conditions,
 

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -475,11 +475,11 @@ end
 
 
 """
-    renamed_xtal = rename(xtal, "new name")
+    renamed_xtal = rename_xtal(xtal, "new name")
 
 Returns a copy of a crystal with the name changed.
 """
-function rename(xtal::Crystal, name::String)::Crystal
+function rename_xtal(xtal::Crystal, name::String)::Crystal
     # make a "nothing" crystal
     nothing_xtal = Crystal(
         "nothing",

--- a/test/crystal.jl
+++ b/test/crystal.jl
@@ -394,7 +394,7 @@ irmof1 = Crystal("IRMOF-1.cif")
 @testset "rename" begin
      xtal1 = deepcopy(sbmof1)
      infer_bonds!(xtal1, true)
-     xtal2 = rename(xtal1, "renamed xtal")
+     xtal2 = rename_xtal(xtal1, "renamed xtal")
 
      # test that crystal is unchanged
      @test isapprox(xtal1.box, xtal2.box)


### PR DESCRIPTION
`rename` caused name clash w/ `DataFrames.rename`, so changed it to `rename_xtal`